### PR TITLE
Mejorando enlace no semántico

### DIFF
--- a/codigo-conducta.html
+++ b/codigo-conducta.html
@@ -135,10 +135,10 @@
                 <a href="mailto:teacht3ch@gmail.com">teacht3ch@gmail.com</a>.
               </p>
               <p>
-                Este código de conducta esta disponible para su libre descarga
+                Este 
                 <a
                   href="https://drive.google.com/file/d/15qAQ6wbc90atFXsl2gK208L9bhHBM8Zw/view?usp=sharing"
-                  >aquí</a
+                  >código de conducta esta disponible para su libre descarga aquí</a
                 >.
               </p>
             </div>


### PR DESCRIPTION
Las personas que usan lectores de pantalla suelen listar la información semántica como enlaces, botones, navegación, etc.
Es recomendable evitar los enlaces que no contienen información semántica sobre los mismos.
He modificado el enlace, pero posiblemente podría mejorarse la frase y hacerla más amigable/comprensible, ejemplo: 
"Si lo deseas, puedes descargar este código de conducta a continuación:" <a hred="xxx">Código de conducta v X.1(PDF XX KB)</a>